### PR TITLE
Add split model method

### DIFF
--- a/dynamicannotationdb/schema.py
+++ b/dynamicannotationdb/schema.py
@@ -96,6 +96,32 @@ class DynamicSchemaClient:
         )
 
     @staticmethod
+    def get_split_models(
+        table_name: str,
+        schema_type: str,
+        segmentation_source: str,
+        table_metadata: dict = None,
+        with_crud_columns: bool = True,
+    ):
+        anno_model = em_models.make_model_from_schema(
+            table_name=table_name,
+            schema_type=schema_type,
+            segmentation_source=None,
+            table_metadata=table_metadata,
+            with_crud_columns=with_crud_columns,
+        )
+        if DynamicSchemaClient.is_segmentation_table_required(schema_type):
+            seg_model = em_models.make_model_from_schema(
+                table_name=table_name,
+                schema_type=schema_type,
+                segmentation_source=segmentation_source,
+                table_metadata=table_metadata,
+                with_crud_columns=with_crud_columns,
+            )
+            return anno_model, seg_model
+        return anno_model, None
+
+    @staticmethod
     def flattened_schema_data(data):
         return flatten_dict(data)
 
@@ -175,9 +201,7 @@ class DynamicSchemaClient:
                         f"{reference_table} must target a different table not {table_name}"
                     )
                 if value not in existing_tables:
-                    raise TableNameNotFound(
-                        f"Reference table target: '{value}' does not exist"
-                    )
+                    raise TableNameNotFound(value)
                 reference_table = value
             elif param == "track_target_id_updates":
                 track_updates = value

--- a/dynamicannotationdb/schema.py
+++ b/dynamicannotationdb/schema.py
@@ -103,6 +103,10 @@ class DynamicSchemaClient:
         table_metadata: dict = None,
         with_crud_columns: bool = True,
     ):
+        """Return the annotation and segmentation models from a
+        supplied schema. If the schema type requires no segmentation fields
+        return only the annotation model and None for the segmentation model.
+        """
         anno_model = em_models.make_model_from_schema(
             table_name=table_name,
             schema_type=schema_type,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -53,24 +53,24 @@ def test_get_table_row_count(dadb_interface, annotation_metadata):
     logging.info(f"{table_name} row count: {result}")
     assert result == 3
 
+
 def test_get_table_valid_row_count(dadb_interface, annotation_metadata):
     table_name = annotation_metadata["table_name"]
 
-    result = dadb_interface.database.get_table_row_count(
-        table_name, filter_valid=True
-    )
+    result = dadb_interface.database.get_table_row_count(table_name, filter_valid=True)
     logging.info(f"{table_name} valid row count: {result}")
     assert result == 2
 
 
 def test_get_table_valid_timestamp_row_count(dadb_interface, annotation_metadata):
     table_name = annotation_metadata["table_name"]
-    ts = datetime.datetime.utcnow() - datetime.timedelta(days=5) 
+    ts = datetime.datetime.utcnow() - datetime.timedelta(days=5)
     result = dadb_interface.database.get_table_row_count(
         table_name, filter_valid=True, filter_timestamp=str(ts)
     )
     logging.info(f"{table_name} valid and timestamped row count: {result}")
-    assert result == 0 
+    assert result == 0
+
 
 def test_get_annotation_table_size(dadb_interface, annotation_metadata):
     table_name = annotation_metadata["table_name"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -41,6 +41,28 @@ def test_create_reference_annotation_model(dadb_interface):
     assert isinstance(valid_ref_schema, DeclarativeMeta)
 
 
+def test_get_split_model(dadb_interface):
+    anno_model, seg_model = dadb_interface.schema.get_split_models(
+        "test_synapse_2", "synapse", "test_annodb"
+    )
+
+    assert isinstance(anno_model, DeclarativeMeta)
+    assert isinstance(seg_model, DeclarativeMeta)
+
+
+def test_get_split_model_with_no_seg_columns(dadb_interface):
+    table_metadata = {"reference_table": "test_synapse_2"}
+    anno_model, seg_model = dadb_interface.schema.get_split_models(
+        table_name="test_simple_group",
+        schema_type="reference_simple_group",
+        segmentation_source="test_annodb",
+        table_metadata=table_metadata,
+    )
+
+    assert isinstance(anno_model, DeclarativeMeta)
+    assert seg_model == None
+
+
 def test_create_flat_model(dadb_interface):
     valid_ref_schema = dadb_interface.schema.create_flat_model(
         "test_flat_table_1",


### PR DESCRIPTION
Helper method that returns both the annotation and segmentation models for a given schema. 